### PR TITLE
Drop Fluentd v0.10.x support

### DIFF
--- a/fluent-plugin-json-lookup.gemspec
+++ b/fluent-plugin-json-lookup.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'fluentd', ['>= 0.10.58', '< 2']
+  gem.add_dependency 'fluentd', ['>= 0.12.0', '< 2']
   gem.add_runtime_dependency 'yajl-ruby', '~> 1.0'
   gem.add_development_dependency 'rake', '>= 0.9.2'
   gem.add_development_dependency('test-unit', ['~> 3.1.4'])

--- a/lib/fluent/plugin/filter_json_lookup.rb
+++ b/lib/fluent/plugin/filter_json_lookup.rb
@@ -2,7 +2,6 @@ require 'fluent/filter'
 require 'yajl'
 
 module Fluent
-  if defined?(Filter)
     class JsonLookupFilter < Filter
       Fluent::Plugin.register_filter('json_lookup', self)
 
@@ -81,5 +80,4 @@ using `lookup_key`'s value, rather than a hard-coded value.
         new_es
       end
     end
-  end
 end

--- a/lib/fluent/plugin/filter_json_lookup.rb
+++ b/lib/fluent/plugin/filter_json_lookup.rb
@@ -2,82 +2,82 @@ require 'fluent/filter'
 require 'yajl'
 
 module Fluent
-    class JsonLookupFilter < Filter
-      Fluent::Plugin.register_filter('json_lookup', self)
+  class JsonLookupFilter < Filter
+    Fluent::Plugin.register_filter('json_lookup', self)
 
-      config_param :lookup_key,
-                   :string,
-                   default: nil,
-                   desc: <<-DESC
+    config_param :lookup_key,
+                 :string,
+                 default: nil,
+                 desc: <<-DESC
 The `lookup_key` is used in looking up the contents of the `json_key`.
-      DESC
+    DESC
 
-      config_param :use_lookup_key_value,
-                   :bool,
-                   default: true,
-                   desc: <<-DESC
+    config_param :use_lookup_key_value,
+                 :bool,
+                 default: true,
+                 desc: <<-DESC
 When `use_lookup_key_value` is set to `true`, the plugin performs the lookup
 using `lookup_key`'s value, rather than a hard-coded value.
-      DESC
+    DESC
 
-      config_param :json_key,
-                   :string,
-                   default: nil,
-                   desc: 'The `json_key`` is a key that contains a string of json.'
+    config_param :json_key,
+                 :string,
+                 default: nil,
+                 desc: 'The `json_key`` is a key that contains a string of json.'
 
-      config_param :remove_json_key,
-                   :bool,
-                   default: false,
-                   desc: 'Remove the `json_key` from each record. Defaults to false.'
+    config_param :remove_json_key,
+                 :bool,
+                 default: false,
+                 desc: 'Remove the `json_key` from each record. Defaults to false.'
 
-      BUILTIN_CONFIGURATIONS = %w(
-        type @type log_level @log_level id @id lookup_key json_key
-        use_lookup_key_value remove_json_key
-      ).freeze
+    BUILTIN_CONFIGURATIONS = %w(
+      type @type log_level @log_level id @id lookup_key json_key
+      use_lookup_key_value remove_json_key
+    ).freeze
 
-      def configure(conf)
-        super
+    def configure(conf)
+      super
 
-        conf.each_pair do |k, v|
-          unless BUILTIN_CONFIGURATIONS.include?(k)
-            conf.key(k)
-            log.warn "Extra key provided! Ignoring '#{k} #{v}'"
-          end
+      conf.each_pair do |k, v|
+        unless BUILTIN_CONFIGURATIONS.include?(k)
+          conf.key(k)
+          log.warn "Extra key provided! Ignoring '#{k} #{v}'"
         end
-
-        # GC.start
       end
 
-      def deserialize_and_lookup(content, lookup)
-        values = {}
-        begin
-          deserialized = Yajl.load(content)
-          if deserialized.is_a?(Hash) && deserialized.key?(lookup) && deserialized[lookup].is_a?(Hash)
-            values = deserialized[lookup]
-          end
-        rescue Yajl::ParseError
-          log.error "Error in plugin json_lookup, error parsing json_key's value #{content}'"
-        end
-        values
-      end
-
-      def filter_stream(_tag, es)
-        new_es = MultiEventStream.new
-        es.each do |time, record|
-          values = {}
-          if record.key?(@json_key)
-            lookup = @use_lookup_key_value ? record[@lookup_key] : @lookup_key
-            if record[@json_key][0] == '{'
-              values = deserialize_and_lookup(record[@json_key], lookup)
-            end
-          end
-          record.merge!(values)
-
-          record.delete(@json_key) if @remove_json_key && record.key?(@json_key)
-
-          new_es.add(time, record)
-        end
-        new_es
-      end
+      # GC.start
     end
+
+    def deserialize_and_lookup(content, lookup)
+      values = {}
+      begin
+        deserialized = Yajl.load(content)
+        if deserialized.is_a?(Hash) && deserialized.key?(lookup) && deserialized[lookup].is_a?(Hash)
+          values = deserialized[lookup]
+        end
+      rescue Yajl::ParseError
+        log.error "Error in plugin json_lookup, error parsing json_key's value #{content}'"
+      end
+      values
+    end
+
+    def filter_stream(_tag, es)
+      new_es = MultiEventStream.new
+      es.each do |time, record|
+        values = {}
+        if record.key?(@json_key)
+          lookup = @use_lookup_key_value ? record[@lookup_key] : @lookup_key
+          if record[@json_key][0] == '{'
+            values = deserialize_and_lookup(record[@json_key], lookup)
+          end
+        end
+        record.merge!(values)
+
+        record.delete(@json_key) if @remove_json_key && record.key?(@json_key)
+
+        new_es.add(time, record)
+      end
+      new_es
+    end
+  end
 end


### PR DESCRIPTION
Because:
 * This plugin does not have output plugin
 * Fluentd v0.10.x has been EOL
   * https://groups.google.com/forum/#!topic/fluentd/c4f9j9VMWkA